### PR TITLE
0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RoReplicate 0.2.4
+# RoReplicate 0.2.5
 A set of ModuleScripts for utilization in easier plugin creation, which blends in with the default Roblox Studio look. StudioWidgets is planned to be incorportated for ease of use (Rather than say, developing some classes yourself ontop of RoReplicate to achieve the desired look/functionality).
 
 ## Overview

--- a/src/RoReplicateBase.lua
+++ b/src/RoReplicateBase.lua
@@ -34,10 +34,28 @@ function RoReplicateBaseClass.new(pluginName, pluginInfo)
 	self._sizeMin = UDim2.new(0,0,0,0)
 	self._sizeMax = UDim2.new(0,0,0,0)
 	
-	local uiListLayout = Instance.new("UIListLayout", frame)
-	uiListLayout.Padding = UDim.new(1,4)
+	local topFrame = Instance.new("Frame", frame)
+	topFrame.Size = UDim2.new(1,0,0,23)
+	topFrame.Position = UDim2.new(0,0,0,0)
+	topFrame.BorderSizePixel = 1
+	RoReplicateUtility:SyncBorderColor3(topFrame)
+	RoReplicateUtility:SyncTitlebar(topFrame)
+	
+	--TODO topFrame uiListLayout
+	
+	local sectionFrame = Instance.new("Frame", frame)
+	sectionFrame.Size = UDim2.new(1,0,0,99)
+	sectionFrame.Position = UDim2.new(0,0,0,23)
+	sectionFrame.BackgroundTransparency = .5
+	sectionFrame.ZIndex = 0
+	self._sectionFrame = sectionFrame
+	
+	
+	local uiListLayout = Instance.new("UIListLayout", sectionFrame)
+	uiListLayout.Padding = UDim.new(0,0)
 	uiListLayout.FillDirection = Enum.FillDirection.Horizontal
 	uiListLayout.SortOrder = Enum.SortOrder.LayoutOrder
+	uiListLayout.HorizontalAlignment = Enum.HorizontalAlignment.Left
 	uiListLayout.VerticalAlignment = Enum.VerticalAlignment.Center
 	
 	return self
@@ -52,6 +70,7 @@ function RoReplicateBaseClass:AddSections(...)
 	local arg = {...}
 	for i=1, #arg do
 		assert(getmetatable(arg[i])==getmetatable(Section.new("","")), "RoReplicateBaseClass:AddSection - Parameter "..i.." is not a SectionClass")
+		arg[i]:GetFrame().Parent = self._sectionFrame
 		if not pcall(function()
 				self._sections = table.insert(self._sections, #self._sections+1, arg[i])
 			end)
@@ -71,6 +90,7 @@ function RoReplicateBaseClass:RemoveSections(...)
 	local arg = {...}
 	for i=1, #arg do
 		assert(getmetatable(arg[i])==getmetatable(Section.new("","")), "RoReplicateBaseClass:AddSection - Parameter "..i.." is not a SectionClass")
+		arg[i]:GetFrame().Parent = nil
 		if not pcall(function()
 				self._sections = table.remove(self._sections, table.find(self._sections, arg[i]))
 			end)
@@ -123,9 +143,9 @@ function RoReplicateBaseClass:_UpdateSize()
 	local _x = 0 --#of sections * amount of widgets in each + divider size
 	local TEMP = 1 --TODO <- remove this ugly thing
 	
-	self._sizeMin = UDim2.new(TEMP, _x, 0, 100) --height is 96-100 pixels at 1920x1080, will have to recalculate for other displays
+	self._sizeMin = UDim2.new(TEMP, _x, 0, 122) --height is 96-100 pixels at 1920x1080, will have to recalculate for other displays
 	
-	self._sizeDef = UDim2.new(TEMP, _x, 0, 100)
+	self._sizeDef = UDim2.new(TEMP, _x, 0, 122)
 end
 
 

--- a/src/RoReplicateEnum.lua
+++ b/src/RoReplicateEnum.lua
@@ -9,7 +9,7 @@ RoReplicateEnumClass.Panel.ButtomImageText = {}
 - Internal code used for creating a Custom panel type
 --]]
 function RoReplicateEnumClass.Panel.Custom()
-  --this is purposely left empty, used for assertations moreso than anything
+	--this is purposely left empty, used for assertations moreso than anything
 end
 
 
@@ -17,8 +17,11 @@ end
 - Internal code used for creating a ButtonImageText panel type
 --]]
 function RoReplicateEnumClass.Panel.ButtomImageText()
-  local frame = Instance.new("Frame")
-  --TODO
+	local frame = Instance.new("Frame")
+	
+	local textButton = Instance.new("TextButton", frame)
+	
+	local imageButton = Instance.new("ImageButton", frame)
 end
 
 

--- a/src/RoReplicateUtility.lua
+++ b/src/RoReplicateUtility.lua
@@ -1,7 +1,9 @@
 local TestService = game:GetService("TestService")
 
+
 RoReplicateUtility = {}
 --RoReplicateUtility.__index = RoReplicateUtility
+
 
 --https://developer.roblox.com/en-us/api-reference/function/StudioTheme/GetColor
 --https://developer.roblox.com/en-us/api-reference/enum/StudioStyleGuideColor
@@ -12,9 +14,20 @@ function RoReplicateUtility:SyncBackgroundColor3(gui)
 	gui.BackgroundColor3 = settings().Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
 end
 
+
 function RoReplicateUtility:SyncTextColor3(gui)
 	gui.TextColor3 = settings().Studio.Theme:GetColor(Enum.StudioStyleGuideColor.ButtonText)
 end
 
-return RoReplicateUtility
 
+function RoReplicateUtility:SyncTitlebar(gui)
+	gui.BackgroundColor3 = settings().Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Titlebar)
+end
+
+
+function RoReplicateUtility:SyncBorderColor3(gui)
+	gui.BorderColor3 = settings().Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Border)
+end
+
+
+return RoReplicateUtility

--- a/src/Section.lua
+++ b/src/Section.lua
@@ -21,17 +21,19 @@ function SectionClass.new(nameSuffix, titleText)
 	
 	local frame = Instance.new("Frame")
 	frame.Name = "Section"..nameSuffix
-	frame.BackgroundTransparency = 1
-	frame.LayoutOrder = 1
+	frame.BackgroundTransparency = 0
+	frame.Size = UDim2.new(0, 512, 1, 0)
+	frame.Position = UDim2.new(0,0,0,1)
+	frame.ZIndex = 100
 	self._frame = frame
 	
-	local contentsFrame = Instance.new("Frame")
+	local contentsFrame = Instance.new("Frame", frame)
 	contentsFrame.Name = "Contents"
-	contentsFrame.BackgroundTransparency = 1
-	contentsFrame.Size = UDim2.new(1, 0, .8, 0) 
+	contentsFrame.BackgroundTransparency = 0
+	contentsFrame.Size = UDim2.new(0, 256, 0, 72) 
 	contentsFrame.Position = UDim2.new(0, 0, 0, 0)
 	contentsFrame.Parent = frame
-	contentsFrame.LayoutOrder = 2
+	contentsFrame.ZIndex = 200
 	self._contentsFrame = contentsFrame
 	
 	local arrayPan = {}
@@ -55,6 +57,7 @@ function SectionClass:AddPanels(...)
 	local arg = {...}
 	for i=1, #arg do
 		assert(getmetatable(arg[i]) == getmetatable(Panel.new(RoReplicateEnum.Panel.Custom)), "SectionClass:AddPanel - parameter "..i.." is not a PanelClass")
+		arg[i].Parent = self._frame
 		if not pcall(function()
 				self._panels = table.insert(self._panels, #self._panels+1, arg[i])	
 			end) 
@@ -71,9 +74,10 @@ end
 - @param ... - Panel Class(es)
 --]]
 function SectionClass:RemovePanel(...)
-	local arg= {...}
+	local arg = {...}
 	for i=1, #arg do
 		assert(getmetatable(arg[i]) == getmetatable(Panel.new(RoReplicateEnum.Panel.Custom)), "SectionClass:AddPanel - parameter "..i.." is not a PanelClass")
+		arg[i].Parent = nil
 		if not pcall(function()
 				self._panels = table.remove(self._panels, table.find(self._panels, arg[i]))
 			end)
@@ -86,6 +90,15 @@ end
 
 
 --[[
+- Returns the current frame
+- @return _frame - frame
+--]]
+function SectionClass:GetFrame()
+	return self._frame
+end
+
+
+--[[TODO FIX to ZIndex
 - Sets the LayoutOrder of the frame of the SectionClass
 - @param int - int
 --]]
@@ -110,18 +123,20 @@ end
 function SectionClass:_CreateBottomFrame(titleText)
 	local frame = Instance.new("Frame")
 	frame.Parent = self._frame
-	frame.Size = UDim2.new(1,0,.2,0) --X full, 20% of Y
-	frame.Position = UDim2.new(.5,0,.9,0) --Midpoints of Size
+	frame.Size = UDim2.new(1,0,0,27) --X full, 20% of Y
+	frame.Position = UDim2.new(0,0,0,72) --Midpoints of Size
 	frame.BackgroundTransparency = 1
+	frame.ZIndex = 300
 	
 	local textLabel = Instance.new("TextLabel", frame)
 	textLabel.Name = "title"
 	textLabel.Size = UDim2.new(1,0,1,0)
-	textLabel.Position = UDim2.new(.5,0,.5,0)
+	textLabel.Position = UDim2.new(0,0,0,0)
 	textLabel.TextXAlignment = Enum.TextXAlignment.Center
 	textLabel.TextYAlignment = Enum.TextYAlignment.Center
 	textLabel.BackgroundTransparency = 1
 	RoReplicateUtility:SyncTextColor3(textLabel)
+	textLabel.ZIndex = 400
 	
 	return frame
 end


### PR DESCRIPTION
## RoReplicate 0.2.5 — 22 June 2020

### Changes
Started replication of Studio Theme for 1920x1080. Starting out sizing out some stuff. Uses offset pixel measurements rather than scalar. Eventually a reverse engineering of the pixel measurements can give scalar results which can be approximated to other resolutions. Hency, why down below the 4K resolution has 2nd priority
![image](https://user-images.githubusercontent.com/24193268/85264472-5b3a4300-b436-11ea-9bbb-29bf09005f02.png)

Planned implementation for other standard resolutions (lowest number indicates priority)
- 1366x768   [3]
- 1600x900   [TBD]
- 1920x1080 [1]
- 1900x1200 [TBD]
- 2560x1440 [4]
- 2560x1600 [TBD]
- 3840x2160 [2]

