### PR TITLE
0.2.10 - Initial CategoryClass creation and PanelClass -> InputClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RoReplicate 0.2.9
+# RoReplicate 0.2.10
 A set of ModuleScripts for utilization in easier plugin creation, which blends in with the default Roblox Studio look. StudioWidgets is planned to be incorportated for ease of use (Rather than say, developing some classes yourself ontop of RoReplicate to achieve the desired look/functionality).
 
 ## Overview

--- a/src/Category.lua
+++ b/src/Category.lua
@@ -1,0 +1,50 @@
+local Section = require(script.Parent.Section)
+
+CategoryClass = {}
+CategoryClass.__Index = CategoryClass
+
+function CategoryClass.new(categoryName)
+	local self = {}
+	setmetatable(self, CategoryClass)
+	
+	local secArray = {}
+	self._sections = secArray
+	
+	return self
+end
+
+
+--[[
+- Adds section(s) to the CategoryClass.
+- @param ... - Section Class(es)
+--]]
+function CategoryClass:AddSections(...)
+	local arg = {...}
+	for i=1, #arg do
+		assert(getmetatable(arg[i])==getmetatable(Section.new("","")), "CategoryClass:AddSection - Parameter "..i.." is not a SectionClass")
+		--arg[i]:GetFrame().Parent = self, disabled for now
+		table.insert(self._sections, #self._sections+1, arg[i])
+	end
+end
+
+
+--[[
+- Removes section(s) to the CategoryClass.
+- @parma ... - Section Class(es)
+--]]
+function CategoryClass:RemoveSections(...)
+	local arg = {...}
+	for i=1, #arg do
+		assert(getmetatable(arg[i])==getmetatable(Section.new("","")), "CategoryClass:AddSection - Parameter "..i.." is not a SectionClass")
+		arg[i]:GetFrame().Parent = nil
+		table.remove(self._sections, table.find(self._sections, arg[i]))
+	end
+end 
+
+
+--[[
+-TODO
+--]]
+function CategoryClass:GetSections()
+	return self._sections
+end

--- a/src/Input.lua
+++ b/src/Input.lua
@@ -1,17 +1,17 @@
 local RoReplicateUtility = require(script.Parent.RoReplicateUtility)
 
 
-PanelClass = {}
-PanelClass.__index = PanelClass
+InputClass = {}
+InputClass.__index = InputClass
 
 
 --[[
-- Creates a new panel
-- @param tuple - PanelType (tuple varies from paneltype to paneltype)
+- Creates a new input
+- @param tuple - InputType (tuple varies from inputtype to inputtype)
 --]]
-function PanelClass.new(enum, Section)
+function InputClass.new(enum, Section)
 	local self = {}
-	setmetatable(self, PanelClass)
+	setmetatable(self, InputClass)
 	
 	local frame = Instance.new("Frame")
 	frame.BackgroundTransparency = 0
@@ -22,7 +22,7 @@ function PanelClass.new(enum, Section)
 	
 	pcall(
 		function()
-			Section:AddPanels(self)
+			Section:AddInputs(self)
 		end
 	)
 	
@@ -31,29 +31,29 @@ end
 
 
 --[[
-- Returns the frame of the panel for local script manipulation
+- Returns the frame of the input for local script manipulation
 - @return frame - Frame Instance
 --]]
-function PanelClass:GetFrame()
+function InputClass:GetFrame()
 	return self._frame
 end
 
 
 --[[
-- Sets the frame of the panel from any local script manipulation
+- Sets the frame of the input from any local script manipulation
 --]]
-function PanelClass:SetFrame(frame)
-	assert(getmetatable(frame) == getmetatable(Instance.new("Frame")), "PanelClass:SetFrame - tried to SetFrame to something that is not a Frame Instance")
+function InputClass:SetFrame(frame)
+	assert(getmetatable(frame) == getmetatable(Instance.new("Frame")), "InputClass:SetFrame - tried to SetFrame to something that is not a Frame Instance")
 	self._frame = frame
 end
 
 
-PanelClass.Enum = {}
+InputClass.Enum = {}
 
 --[[
 - TODO
 --]]
-function PanelClass:_CheckEnum(enum)
+function InputClass:_CheckEnum(enum)
 	if not pcall(
 		function()
 			enum.new(self._frame)
@@ -63,23 +63,23 @@ function PanelClass:_CheckEnum(enum)
 end
 
 
-PanelClass.Enum.CustomInput = {}
-PanelClass.Enum.CustomInput.__index = {}
+InputClass.Enum.CustomInput = {}
+InputClass.Enum.CustomInput.__index = {}
 
-function PanelClass.Enum.CustomInput.new(gui)
+function InputClass.Enum.CustomInput.new(gui)
 	local self = {}
-	setmetatable(self, PanelClass.Enum.ButtonImage)
+	setmetatable(self, InputClass.Enum.ButtonImage)
 	
 	return self
 end
 
 
-PanelClass.Enum.ButtonImage = {}
-PanelClass.Enum.ButtonImage.__index = {}
+InputClass.Enum.ButtonImage = {}
+InputClass.Enum.ButtonImage.__index = {}
 
-function PanelClass.Enum.ButtonImage.new(gui)
+function InputClass.Enum.ButtonImage.new(gui)
 	local self = {}
-	setmetatable(self, PanelClass.Enum.ButtonImage)
+	setmetatable(self, InputClass.Enum.ButtonImage)
 	
 	local frame = Instance.new("Frame", gui)
 	frame.BackgroundTransparency = 1
@@ -117,4 +117,4 @@ function PanelClass.Enum.ButtonImage.new(gui)
 end
 
 
-return PanelClass
+return InputClass

--- a/src/Section.lua
+++ b/src/Section.lua
@@ -1,5 +1,5 @@
 local RoReplicateUtility = require(script.Parent.RoReplicateUtility)
-local Panel = require(script.Parent.Panel)
+local Input = require(script.Parent.Input)
 
 
 SectionClass = {}
@@ -33,8 +33,8 @@ function SectionClass.new(nameSuffix, titleText, RoReplicateBase)
 	contentsFrame.Size = UDim2.new(0, 0, 0, 0) 
 	self._contentsFrame = contentsFrame
 	
-	local arrayPan = {}
-	self._panels = arrayPan
+	local inputPan = {}
+	self._inputs = inputPan
 	
 	local uiListLayout = Instance.new("UIListLayout", contentsFrame)
 	uiListLayout.Padding = UDim.new(0,4)
@@ -55,30 +55,30 @@ end
 
 
 --[[
-- Adds Panel Class(es) to this Section
-- @param ... - Panel Class(es)
+- Adds Input Class(es) to this Section
+- @param ... - Input Class(es)
 --]]
-function SectionClass:AddPanels(...)
+function SectionClass:AddInputs(...)
 	local arg = {...}
 	for i=1, #arg do
-		assert(true, "SectionClass:AddPanel - parameter "..i.." is not a PanelClass") --TODO ASSERTATION
+		assert(true, "SectionClass:AddInput - parameter "..i.." is not a InputClass") --TODO ASSERTATION
 		arg[i]:GetFrame().Parent = self._contentsFrame
-		table.insert(self._panels, #self._panels+1, arg[i])	
+		table.insert(self._inputs, #self._inputs+1, arg[i])	
 	end
 	self:_UpdateSize()
 end
 
 
 --[[
-- Removes Panel Class(es) to this Section
-- @param ... - Panel Class(es)
+- Removes Input Class(es) to this Section
+- @param ... - Input Class(es)
 --]]
-function SectionClass:RemovePanel(...)
+function SectionClass:RemoveInput(...)
 	local arg = {...}
 	for i=1, #arg do
-		assert(getmetatable(arg[i]) == getmetatable(Panel.new(RoReplicateEnum.Panel.Custom)), "SectionClass:AddPanel - parameter "..i.." is not a PanelClass")
+		assert(getmetatable(arg[i]) == getmetatable(Input.new(Input.Enum.Custom)), "SectionClass:AddInput - parameter "..i.." is not a InputClass")
 		arg[i]:GetFrame().Parent = nil
-		table.remove(self._panels, table.find(self._panels, arg[i]))
+		table.remove(self._inputs, table.find(self._inputs, arg[i]))
 	end
 end
 
@@ -102,11 +102,11 @@ end
 
 
 --[[
-- Returns an array of panels for script manipulation elsewhere
-- @return _panels - PanelClass array
+- Returns an array of inputs for script manipulation elsewhere
+- @return _inputs - InputClass array
 --]]
-function SectionClass:GetPanels()
-	return self._panels
+function SectionClass:GetInputs()
+	return self._inputs
 end
 
 
@@ -137,9 +137,9 @@ end
 --]]
 function SectionClass:_UpdateSize()
 	local total = UDim2.new(0,0,0,0)
-	local fluff = 4*(#self._panels - 1)
-	for i=1, #self._panels do
-		total += self._panels[i]:GetFrame().Size
+	local fluff = 4*(#self._inputs - 1)
+	for i=1, #self._inputs do
+		total += self._inputs[i]:GetFrame().Size
 	end
 	
 	self._frame.Size = UDim2.new(0,total.X.Offset+fluff+8,1,0)

--- a/src/_RoReplicateDemoScript.lua
+++ b/src/_RoReplicateDemoScript.lua
@@ -3,11 +3,11 @@ local RoReplicate = script.Parent
 local RoReplicateBase = require(RoReplicate.RoReplicateBase)
 local RoReplicateUtility = require(RoReplicate.RoReplicateUtility)
 local Section = require(RoReplicate.Section)
-local Panel = require(RoReplicate.Panel)
+local Input = require(RoReplicate.Input)
 
 --https://developer.roblox.com/en-us/api-reference/datatype/DockWidgetPluginGuiInfo
 local pluginInfo = DockWidgetPluginGuiInfo.new(
-	Enum.InitialDockState.Float,  -- Widget will be initialized in floating panel
+	Enum.InitialDockState.Float,  -- Widget will be initialized in floating input
 	true,   -- Widget will be initially enabled
 	true  -- Don't override the previous enabled state
 )
@@ -20,12 +20,12 @@ local section_1 = Section.new("1", "Section 1", roPlugin)
 local section_2 = Section.new("2", "Section 2", roPlugin)
 --roPlugin:AddSections(section_1, section_2) --This parents it to the BaseClass
 
-local s1_panel_1 = Panel.new(Panel.Enum.ButtonImage, section_1)
-local s1_panel_2 = Panel.new(Panel.Enum.ButtonImage, section_1)
---section_1:AddPanels(s1_panel_1, s1_panel_2) --This parents it to the BaseClass
+local s1_input_1 = Input.new(Input.Enum.ButtonImage, section_1)
+local s1_input_2 = Input.new(Input.Enum.ButtonImage, section_1)
+--section_1:AddInputs(s1_input_1, s1_input_2) --This parents it to the BaseClass
 
 for i=1, 4 do
-	local panel = Panel.new(Panel.Enum.ButtonImage, section_2)
+	local input = Input.new(Input.Enum.ButtonImage, section_2)
 end
 
 


### PR DESCRIPTION
## RoReplicate 0.2.10 — 29 June 2020

### Changes
* Changed the name of all PanelClass.lua and relevant references to InputClass.lua
  * More transparent name about utility of the class.
  * Possible implementation to support showing some inputs on the RoReplicateBase.topFrame
  
* Initial creation of the CategoryClass, utilized for creation of categories, which stores SectionClasses. 
  * CategoryClass is accessed/changed in-between through the RoReplicateBase.topFrame
  * If a SectionClass isn't assigned a CategoryClass they won't be displayed (TBD?).
  * Similiar to the File, Home, Model, Test, View, Plugins, and Script Menu on the native Roblox Studio UI.
